### PR TITLE
Rename to SDK Chat throughout project

### DIFF
--- a/VERCEL_SDK_V5_BEST_PRACTICES.md
+++ b/VERCEL_SDK_V5_BEST_PRACTICES.md
@@ -1,8 +1,8 @@
 # Vercel AI SDK v5 Best Practices Guide
 
-**NerdChat** - A Reference Implementation
+**SDK Chat** - A Reference Implementation
 
-This document explains how NerdChat demonstrates best practices for using Vercel AI SDK v5 (`@ai-sdk/react` v2.x and `ai` v5.x) in a production-ready Next.js application.
+This document explains how SDK Chat demonstrates best practices for using Vercel AI SDK v5 (`@ai-sdk/react` v2.x and `ai` v5.x) in a production-ready Next.js application.
 
 ---
 
@@ -20,9 +20,9 @@ This document explains how NerdChat demonstrates best practices for using Vercel
 
 ## Overview
 
-### What is NerdChat?
+### What is SDK Chat?
 
-NerdChat is a modern chat interface that demonstrates proper integration with Vercel AI SDK v5. It supports:
+SDK Chat is a modern chat interface that demonstrates proper integration with Vercel AI SDK v5. It supports:
 - Multiple AI models (Gemini, Claude)
 - Real-time streaming responses
 - Custom API endpoints
@@ -581,7 +581,7 @@ export async function POST(req: NextRequest) {
 
 ### 1. Reasoning/Thinking Content
 
-NerdChat demonstrates handling special content types:
+SDK Chat demonstrates handling special content types:
 
 ```typescript
 const hasReasoningContent = messages.some((m) => 
@@ -794,7 +794,7 @@ test('sends message on form submit', async () => {
 
 ## Conclusion
 
-NerdChat demonstrates **production-ready patterns** for Vercel AI SDK v5:
+SDK Chat demonstrates **production-ready patterns** for Vercel AI SDK v5:
 
 1. ✅ Correct hook usage (`useChat` from `@ai-sdk/react`)
 2. ✅ Manual input state management

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,7 +6,7 @@ import { Inter } from 'next/font/google';
 const inter = Inter({ subsets: ['latin'] });
 
 export const metadata: Metadata = {
-  title: 'NerdChat - AI Chat Interface',
+  title: 'SDK Chat - AI Chat Interface',
   description: 'A polished chat interface powered by Vercel AI SDK v5',
 };
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -189,7 +189,7 @@ export default function Page() {
           <div className="flex flex-col md:flex-row md:items-center justify-between gap-3">
             <div className="flex items-center gap-3">
               <Sparkles className="h-6 w-6 text-primary" />
-              <h1 className="text-xl font-bold">NerdChat</h1>
+              <h1 className="text-xl font-bold">SDK Chat</h1>
               <Badge variant="secondary" className="hidden md:inline-flex">
                 {MODEL_DISPLAY_NAMES[model]}
               </Badge>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "nerdchat-vercel-ai-v5-test",
+  "name": "sdk-chat-vercel-ai-v5-test",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "nerdchat-vercel-ai-v5-test",
+      "name": "sdk-chat-vercel-ai-v5-test",
       "version": "0.1.0",
       "dependencies": {
         "@ai-sdk/openai-compatible": "latest",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "nerdchat-vercel-ai-v5-test",
+  "name": "sdk-chat-vercel-ai-v5-test",
   "version": "0.1.0",
   "private": true,
   "scripts": {


### PR DESCRIPTION
Updated all references to 'SDK Chat' in documentation, UI, metadata, and package files to reflect the new project name.